### PR TITLE
Move usage from README to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,32 +5,9 @@ Through research and development, technology costs continue to fall, and governm
 
 The goal is to develop surrogate models that generate data to inform in the design of near-net-zero energy buildings in Canada.
 
+# Documentation
 
-## About this Repo
-
-This repo contains the python Notebooks and codes for the entire surrogate modelling for a full service restaurant. 
-
-## Requirements
-
-* Python 3
-* Access to Minio
-* Docker installed and running on your computer
-* A git client
-* Install the requirement packages
-    ```
-    pip3 install -r requirements.txt
-    ```
-
-
- ## How to run this app
-
-We suggest you create a virtual environment for running the surrogate model with Python and Clone this repository. 
-
-```
-cd c:\users\bukola
-git clone https://github.com/canmet-energy/btap_ml.git
-cd btap_ml
-```
+Refer to the [documentation](docs/) to see how to install and run the model.
 
 ## Structure
 - Block Storage Guide.ipynb: sample notebook of how to access minio using s3f3. 
@@ -41,70 +18,8 @@ cd btap_ml
     - predict.py: builds the surrogate model using the preprocessed data and the selected features described above
     - plot.py: contains functions used to create plots. 
     
-## how to use
+### License
 
-Option 1: Run the surrogate model without using the kubeflow pipeline.
+Unless otherwise noted, the source code of this project is covered under Crown Copyright, Government of Canada, and is distributed under the [GNU GPL v3 License](LICENSE).
 
-```
-cd src
-```
-
-- **step 1)** Preprocessing
-    - You need to type the command below into a terminal
-    * Notes: check to ensure the file paths specified for the arguements below exist in minio
-        - in_build_params: the simulation I/O output file used in buiding and testing the model.
-        - in_hour: the hourly energy file associated with the in_build_params file.
-        - in_build_params_val: the simulation I/O output file used in validating the model.
-        - in_hour_val: the hourly energy file associated with the in_build_params_val file.
-        - in_weather: the epw file converted to csv. 
-    ```
-    python3 preprocessing.py --tenant standard --bucket nrcan-btap --in_build_params input_data/output_2021-10-04.xlsx --in_hour input_data/total_hourly_res_2021-10-04.csv --in_weather input_data/montreal_epw.csv --output_path output_data/preprocessing_out --in_build_params_val input_data/output.xlsx --in_hour_val input_data/total_hourly_res.csv
-    ```
-
-- **step 2)** Feature Selection
-    - Run the command below from a terminal
-     ```
-    python3 feature_selection.py --tenant standard --bucket nrcan-btap --in_obj_name output_data/preprocessing_out --output_path output_data/feature_out --estimator_type elasticnet
-    ```
-   
-- **step 3)** Building the Surrogate Model:
-    Option A: No hyperparameter search.
-    - The surrogate model can be built usind default parameters by setting the value of --param_search as no
-    ```
-    python3 feature_selection.py --tenant standard --bucket nrcan-btap --in_obj_name output_data/preprocessing_out --output_path output_data/feature_out --estimator_type elasticnet```python3 predict.py --tenant standard --bucket nrcan-btap --param_search no --in_obj_name output_data/preprocessing_out --features output_data/feature_out --output_path output_data/predict_out 
-    ```
-    Option B: With hyperparameter search.
-    - The surrogate model can be built usind default parameters by setting the value of --param_search as yes
-    ```
-    python3 feature_selection.py --tenant standard --bucket nrcan-btap --in_obj_name output_data/preprocessing_out --output_path output_data/feature_out --estimator_type elasticnet```python3 predict.py --tenant standard --bucket nrcan-btap --param_search yes --in_obj_name output_data/preprocessing_out --features output_data/feature_out --output_path output_data/predict_out 
-    ```
-    
-- **step 4)** tensorboard (optional):    
-    - run tensorboard.ipynb
-    - using the port opened from tensorboard.ipynb, open the [Tensorboard Dashboard] (https://git-scm.com/downloadshttps://kubeflow.aaw.cloud.statcan.ca/notebook/nrcan-btap/reg-cpu-notebook/proxy/6007/)
-
-
-Option 2: Running the surrogate model as a kubeflow pipeline. 
-- **step 1)** Build Image [THE COMMAND BELOW NEEDS TO BE RECHECKED AND UPDATED]
-    ```
-    cd pipeline
-    docker build -t btap_ml  --build-arg GIT_API_TOKEN=$env:GIT_API_TOKEN .
-    ```
-    
-- **step 2)** Run the pipeline
-    - Check the arguements in the run.py file are correct
-        - in_build_params: the simulation I/O output file used in buiding and testing the model.
-        - in_hour: the hourly energy file associated with the in_build_params file.
-        - in_build_params_val: the simulation I/O output file used in validating the model.
-        - in_hour_val: the hourly energy file associated with the in_build_params_val file.
-        - in_weather: the epw file converted to csv. 
-    ```
-    python3 run.py
-    ```
-    
-                             
- 
-
-
-
-Copyright 2021, Data Science Division - Statistics Canada | Developer: Bukola Ishola
+The Canada wordmark and related graphics associated with this distribution are protected under trademark law and copyright law. No permission is granted to use them outside the parameters of the Government of Canada's corporate identity program. For more information, see [Federal identity requirements](https://www.canada.ca/en/treasury-board-secretariat/topics/government-communications/federal-identity-requirements.html).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,10 +19,19 @@ required to produce usable outputs.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Contents
 
    installation
    aaw_setup
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Usage
+
+   usage/preprocessing
+   usage/feature_selection
+   usage/build_model
+   usage/kubeflow_pipeline
 
 Indices and tables
 ==================

--- a/docs/usage/build_model.rst
+++ b/docs/usage/build_model.rst
@@ -1,0 +1,28 @@
+Model building
+==============
+
+There are two options when building the model: (1) with hyperparameter search, and (2) without hyperparameter search.
+Hyperparameter search is controlled by the ``--param_search`` switch on ``feature_selection.py``.
+
+With hyperparameter search::
+
+    python3 feature_selection.py --tenant standard --bucket nrcan-btap --in_obj_name output_data/preprocessing_out --output_path output_data/feature_out --estimator_type elasticnet```python3 predict.py --tenant standard --bucket nrcan-btap --param_search no --in_obj_name output_data/preprocessing_out --features output_data/feature_out --output_path output_data/predict_out 
+
+Without hyperparameter search::
+
+    python3 feature_selection.py --tenant standard --bucket nrcan-btap --in_obj_name output_data/preprocessing_out --output_path output_data/feature_out --estimator_type elasticnet```python3 predict.py --tenant standard --bucket nrcan-btap --param_search yes --in_obj_name output_data/preprocessing_out --features output_data/feature_out --output_path output_data/predict_out 
+
+Tensorboard
+-----------
+
+You can use the tensorboard dashboard to inspect the performance of the model.
+
+1. Open ``notebooks/tensorboard.ipynb``.
+2. Run all the contents of the notebook.
+3. Navigate to the appropriate port in a web browser.
+
+.. note::
+
+   The tensorboard opens on a random port inside your notebook container. The URL looks like 
+   https://kubeflow.aaw.cloud.statcan.ca/notebook/nrcan-btap/<notebook_name>/proxy/<port>/.
+

--- a/docs/usage/feature_selection.rst
+++ b/docs/usage/feature_selection.rst
@@ -1,0 +1,6 @@
+Feature selection
+=================
+
+Feautre selection is performed by running::
+
+    python3 feature_selection.py --tenant standard --bucket nrcan-btap --in_obj_name output_data/preprocessing_out --output_path output_data/feature_out --estimator_type elasticnet

--- a/docs/usage/kubeflow_pipeline.rst
+++ b/docs/usage/kubeflow_pipeline.rst
@@ -1,0 +1,23 @@
+Kubeflow pipeline
+=================
+
+A kubeflow pipeline exists to run the training and modelling steps automatically.
+
+Step 1: build the image [THE COMMAND BELOW NEEDS TO BE RECHECKED AND UPDATED]::
+
+    cd pipeline
+    docker build -t btap_ml  --build-arg GIT_API_TOKEN=$env:GIT_API_TOKEN .
+
+Step 2: run the pipeline
+
+Check the arguements in the run.py file are correct
+
+- in_build_params: the simulation I/O output file used in buiding and testing the model.
+- in_hour: the hourly energy file associated with the in_build_params file.
+- in_build_params_val: the simulation I/O output file used in validating the model.
+- in_hour_val: the hourly energy file associated with the in_build_params_val file.
+- in_weather: the epw file converted to csv.
+
+.. code::
+
+   python3 run.py

--- a/docs/usage/preprocessing.rst
+++ b/docs/usage/preprocessing.rst
@@ -1,0 +1,17 @@
+Preprocessing
+=============
+
+When running manually, you need to trigger the preprocessing step to prepare all the input data. Several 
+inputs are required to prepare for model training:
+
+* the simulation I/O output file used in buiding and testing the model
+* the hourly energy file associated with the in_build_params file
+* the simulation I/O output file used in validating the model
+* the hourly energy file associated with the in_build_params_val file
+* the weather data for your location of interest
+
+# TODO: Explain how validation data was generated
+
+The following command will perform the required preprocessing on the given inputs::
+
+    python3 preprocessing.py --tenant standard --bucket nrcan-btap --in_build_params input_data/output_2021-10-04.xlsx --in_hour input_data/total_hourly_res_2021-10-04.csv --in_weather input_data/montreal_epw.csv --output_path output_data/preprocessing_out --in_build_params_val input_data/output.xlsx --in_hour_val input_data/total_hourly_res.csv


### PR DESCRIPTION
Related to #7, moves usage information into the general structure of the documentation in the `docs` folder.