### PR TITLE
Fix link to DAaaS and ref aaw setup.

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -3,7 +3,8 @@ Installation
 
 This project implements a pipeline designed to run on \*nix based systems, and as such may have requirements not
 documented here to be able to run on Windows. Some elements of this documentation may be specific to running on the
-`DAaaS <https://www.statcan.gc.ca/data-analytics-service/>`_ environment.
+`DAaaS <https://statcan.github.io/daaas/>`_ environment. If you will be working on AAW, you may want to refer to
+:doc:`aaw_setup` to configure the environment first.
 
 Python
 ------


### PR DESCRIPTION
Fixes link to DAaaS to not point to one requiring authentication.
Also explicitly directs reader to perform AAW workspace setup from installation instructions.