### PR TITLE
Update tensorflow to avoid CVE

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,6 @@ s3fs
 scikit_learn
 seaborn
 tensorboard
-tensorflow==2.6.0
-tensorflow_gpu==2.6.0
+tensorflow>=2.6.1
+tensorflow_gpu>=2.6.1
 xgboost==1.4.2


### PR DESCRIPTION
Update is based on dependabot warning about critical CVE found in tensorflow.