### PR TITLE
Add src directory for automodule indexing.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,9 +10,10 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath('../src'))
 
 
 # -- Project information -----------------------------------------------------
@@ -43,7 +44,7 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '.ipynb_checkpoints']
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,6 +39,12 @@ required to produce usable outputs.
    usage/build_model
    usage/kubeflow_pipeline
 
+API
+---
+
+Refer to :ref:`modindex`
+
+
 Indices and tables
 ==================
 

--- a/src/config.py
+++ b/src/config.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Union
 
 import pandas as pd
 import s3fs
@@ -72,7 +72,7 @@ def establish_s3_connection(endpoint_url: str, access_key: str, secret_key: Secr
     return s3
 
 
-def access_minio(path, operation, data):
+def access_minio(path: str, operation: str, data: Union[str, pd.DataFrame]):
     """
     Used to read and write to minio.
 

--- a/src/plot.py
+++ b/src/plot.py
@@ -4,23 +4,23 @@ Contains helper functions used to create chart. The plots created are stored in 
 
 import numpy as np
 import pandas as pd
-import seaborn as sns
 import plotly
+import seaborn as sns
 from matplotlib import pyplot as plt
 
 
-def show_var(btap_data_df):
+def show_var(btap_data_df: pd.DataFrame) -> None:
     num_vars = list(btap_data_df.select_dtypes(include=[np.number]).columns.values)
     df_ax = btap_data_df[num_vars].plot(title='numerical values', figsize=(15, 8))
     plt.savefig('../output/numerical_val_plot.png')
 
 
-def norm_res(btap_data_df):
+def norm_res(btap_data_df: pd.DataFrame):
     results_normed = (btap_data_df - np.mean(btap_data_df)) / np.std(btap_data_df)
     return results_normed
 
 
-def norm_res_plot(btap_data_df):
+def norm_res_plot(btap_data_df: pd.DataFrame) -> None:
     total_heating_use = btap_data_df["daily_energy"]
     plt.scatter(norm_res(btap_data_df[":ext_wall_cond"]), total_heating_use, label="wall cond")
     plt.scatter(norm_res(btap_data_df[":ext_roof_cond"]), total_heating_use, label="roof cond")
@@ -29,7 +29,7 @@ def norm_res_plot(btap_data_df):
     plt.savefig('../output/Total_Energy_Scatter.png')
 
 
-def corr_plot(btap_data_df):
+def corr_plot(btap_data_df: pd.DataFrame) -> None:
     # Using Pearson Correlation
     plt.figure(figsize=(20, 20))
     cor = btap_data_df.corr()
@@ -37,14 +37,14 @@ def corr_plot(btap_data_df):
     plt.savefig('../output/corr_plot.png')
 
 
-def target_plot(y_train, y_test):
+def target_plot(y_train, y_test) -> None:
     plt.figure()
     plt.hist(y_train, label='train')
     plt.hist(y_test, label='test')
     plt.savefig('../output/daily_energy_train.png')
 
 
-def plot_metric(df):
+def plot_metric(df: pd.DataFrame) -> None:
     plt.figure()
     plt.plot(df['loss'], label='mae')
     plt.savefig('./output/mae.png')
@@ -59,7 +59,7 @@ def plot_metric(df):
     return
 
 
-def save_plot(H):
+def save_plot(H) -> None:
     # plot the training loss and accuracy
     plt.style.use("ggplot")
     plt.figure()
@@ -83,7 +83,7 @@ def save_plot(H):
     return
 
 
-def annual_plot(output_df, desc):
+def annual_plot(output_df: pd.DataFrame, desc: str) -> None:
     plt.style.use("ggplot")
     plt.figure()
     plt.plot(output_df['Total Energy'], label='actual')


### PR DESCRIPTION
`automodule` will look into the `src/` directory and index anything in the `.py` files, as per #7.

An API heading was added to draw attention to the module index.