### PR TITLE
Generate API docs

### DIFF
--- a/docs/api/config.rst
+++ b/docs/api/config.rst
@@ -1,0 +1,6 @@
+Config
+======
+
+.. automodule:: config
+   :members:
+   :undoc-members:

--- a/docs/api/feature_selection.rst
+++ b/docs/api/feature_selection.rst
@@ -1,0 +1,6 @@
+Feature selection
+=================
+
+.. automodule:: feature_selection
+   :members:
+   :undoc-members:

--- a/docs/api/plot.rst
+++ b/docs/api/plot.rst
@@ -1,0 +1,6 @@
+Plot
+====
+
+.. automodule:: plot
+   :members:
+   :undoc-members:

--- a/docs/api/predict.rst
+++ b/docs/api/predict.rst
@@ -1,0 +1,6 @@
+Predict
+=======
+
+.. automodule:: predict
+   :members:
+   :undoc-members:

--- a/docs/api/prepare_weather.rst
+++ b/docs/api/prepare_weather.rst
@@ -1,0 +1,6 @@
+Prepare weather
+===============
+
+.. automodule:: prepare_weather
+   :members:
+   :undoc-members:

--- a/docs/api/preprocessing.rst
+++ b/docs/api/preprocessing.rst
@@ -1,0 +1,6 @@
+Preprocessing
+=============
+
+.. automodule:: preprocessing
+   :members:
+   :undoc-members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,7 +44,7 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '.ipynb_checkpoints']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '.ipynb_checkpoints','*/.ipynb_checkpoints']
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,7 @@ After installation, running the processing will generally follow this order:
 
    digraph G {
       bgcolor=transparent;
+      rankdir=LR;
 
       start -> weather -> preprocess -> features -> build -> end;
 
@@ -40,33 +41,39 @@ Contents
 
 .. toctree::
    :maxdepth: 2
+   :caption: Setup
 
    installation
    aaw_setup
 
-Data Prepration
----------------
 
 .. toctree::
    :maxdepth: 2
+   :caption: Data preparation
 
    data_prep/weather
 
-Usage
------
 
 .. toctree::
    :maxdepth: 2
+   :caption: Usage
 
    usage/preprocessing
    usage/feature_selection
    usage/build_model
    usage/kubeflow_pipeline
 
-API
----
 
-Refer to :ref:`modindex`
+.. toctree::
+   :maxdepth: 1
+   :caption: API
+
+   api/config
+   api/feature_selection
+   api/plot
+   api/predict
+   api/prepare_weather
+   api/preprocessing
 
 
 Indices and tables

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 myst-parser
 sphinx-autodoc-typehints
+-r ../requirements.txt

--- a/src/config.py
+++ b/src/config.py
@@ -47,8 +47,6 @@ class Settings(BaseSettings):
         def customise_sources(cls, init_settings, env_settings, file_secret_settings):
             return (init_settings, json_config_settings_source, env_settings, file_secret_settings)
 
-settings = Settings()
-
 
 def establish_s3_connection(endpoint_url: str, access_key: str, secret_key: SecretStr) -> s3fs.S3FileSystem:
     """Used to create a connection to an S3 data store.
@@ -86,6 +84,7 @@ def access_minio(path: str, operation: str, data: Union[str, pd.DataFrame]):
     Returns:
        Dataframe containing the data downladed from minio is returned for read operation and for write operation , null value is returned.
     """
+    settings = Settings()
     # Establish S3 connection
     s3 = establish_s3_connection(settings.MINIO_URL,
                                  settings.MINIO_ACCESS_KEY,

--- a/src/config.py
+++ b/src/config.py
@@ -1,3 +1,4 @@
+"""Load configuration from the environment and provide a single interface for blob storage access."""
 import json
 from pathlib import Path
 from typing import Any, Dict, Union

--- a/src/predict.py
+++ b/src/predict.py
@@ -18,7 +18,7 @@ import tensorflow as tf
 import tensorflow.keras as keras
 # import tensorflow_docs as tfdocs
 # import tensorflow_docs.plots
-import tensorflow_docs.modeling
+# import tensorflow_docs.modeling
 # np.random.seed(1337)
 from keras import backend as K
 from keras import regularizers  # for l2 regularization

--- a/src/prepare_weather.py
+++ b/src/prepare_weather.py
@@ -12,8 +12,10 @@ logger = logging.getLogger(__name__)
 
 def get_config(config_file: str):
     """Load the specified configuration file from blob storage.
+
     Args:
         config_file: Path to the config file relative to the default bucket.
+
     Returns:
         Dictionary of configuration information.
     """
@@ -32,8 +34,10 @@ def get_config(config_file: str):
 def get_weather_df(filename: str) -> pd.DataFrame:
     """Fetch weather data from the main storage location.
     Loads weather files from the NREL/openstudio-standards GitHub repository where they are managed.
+
     Args:
         filename: The filename of a weather file (.epw)
+
     Returns:
         A dataframe of weather data summarized by day.
     """
@@ -60,6 +64,7 @@ def get_weather_df(filename: str) -> pd.DataFrame:
 def save_epw(df: pd.DataFrame, filename: str) -> None:
     """Save preprared EPW data out to blob storage.
     The filename of the original file is used, with the extension replaced with .parquet.
+
     Args:
         df: Pandas DataFrame to be saved out.
         filename: Filename of the source file used to produce the DataFrame.
@@ -93,8 +98,10 @@ def save_epw(df: pd.DataFrame, filename: str) -> None:
 
 def process_weather_file(filename: str):
     """Process a weather file and return the dataframe.
+
     Args:
         filename: The name of the weather file to load, as defined in the building config file.
+
     Returns:
         A pd.DataFrame object with the ready to use weather information.
     """
@@ -116,6 +123,7 @@ def main(config_file: str = typer.Argument(..., help="Path to configuration YAML
     """Take raw EPW files as defined in BTAP YAML configuration and prepare it for use by the model.
     Uses the EnergyPlus configuration to identify and process weather data in EPW format. The weather data is then
     saved to blob storage for use in later processing stages.
+
     Args:
         config_file: Path to the configuration file used for EnergyPlus.
         epw_file_key: The key in the configuration file that has the weather file name(s). Default is ``:epw_file``.

--- a/src/prepare_weather.py
+++ b/src/prepare_weather.py
@@ -1,3 +1,4 @@
+"""Prepare the weather file(s) specified in the YAML configuration to be used by the pipeline."""
 import logging
 
 import pandas as pd

--- a/src/prepare_weather.py
+++ b/src/prepare_weather.py
@@ -20,13 +20,13 @@ def get_config(config_file: str):
     Returns:
         Dictionary of configuration information.
     """
-    logger.info("Establishing connection to S3 store at %s", config.settings.MINIO_URL)
-    s3 = config.establish_s3_connection(config.settings.MINIO_URL,
-                                        config.settings.MINIO_ACCESS_KEY,
-                                        config.settings.MINIO_SECRET_KEY)
+    logger.info("Establishing connection to S3 store at %s", settings.MINIO_URL)
+    s3 = config.establish_s3_connection(settings.MINIO_URL,
+                                        settings.MINIO_ACCESS_KEY,
+                                        settings.MINIO_SECRET_KEY)
 
     # Create a path to the config from the namespace
-    config_file_path = config.settings.NAMESPACE.joinpath(config_file).as_posix()
+    config_file_path = settings.NAMESPACE.joinpath(config_file).as_posix()
     logger.info("Reading config from file %s", config_file_path)
     contents = yaml.safe_load(s3.open(config_file_path, mode='rb'))
     return contents
@@ -42,7 +42,7 @@ def get_weather_df(filename: str) -> pd.DataFrame:
     Returns:
         A dataframe of weather data summarized by day.
     """
-    epw_file_store = config.settings.APP_CONFIG.WEATHER_DATA_STORE
+    epw_file_store = settings.APP_CONFIG.WEATHER_DATA_STORE
 
     # Number of rows in the file that are just providing metadata
     meta_row_count = 8
@@ -75,23 +75,23 @@ def save_epw(df: pd.DataFrame, filename: str) -> None:
         filename = f"{filename}.parquet"
 
     # Bucket used to store weather data.
-    weather_bucket_name = config.settings.APP_CONFIG.WEATHER_BUCKET_NAME
-    logger.info("Weather data will be placed under %s", weather_bucket_name)
+    weather_bucket_name = settings.APP_CONFIG.WEATHER_BUCKET_NAME
+    logger.info("Weather data will be placed under '%s'", weather_bucket_name)
 
     # Establish a connection to the blob store.
-    s3 = config.establish_s3_connection(config.settings.MINIO_URL,
-                                        config.settings.MINIO_ACCESS_KEY,
-                                        config.settings.MINIO_SECRET_KEY)
+    s3 = config.establish_s3_connection(settings.MINIO_URL,
+                                        settings.MINIO_ACCESS_KEY,
+                                        settings.MINIO_SECRET_KEY)
 
     # Make sure the bucket for weather data exists to avoid write errors
-    existing_items = s3.ls(config.settings.NAMESPACE.as_posix())
+    existing_items = s3.ls(settings.NAMESPACE.as_posix())
     if not weather_bucket_name in existing_items:
-        bucket_path = config.settings.NAMESPACE.joinpath(weather_bucket_name).as_posix()
+        bucket_path = settings.NAMESPACE.joinpath(weather_bucket_name).as_posix()
         logger.info("Weather bucket not found, creating %s", bucket_path)
         s3.mkdir(bucket_path)
 
     # Write the data to s3
-    file_path = config.settings.NAMESPACE.joinpath(weather_bucket_name, filename).as_posix()
+    file_path = settings.NAMESPACE.joinpath(weather_bucket_name, filename).as_posix()
     logger.info("Saving weather data to %s", file_path)
     with s3.open(file_path, 'wb') as outfile:
         df.to_parquet(outfile)
@@ -130,7 +130,7 @@ def main(config_file: str = typer.Argument(..., help="Path to configuration YAML
         epw_file_key: The key in the configuration file that has the weather file name(s). Default is ``:epw_file``.
     """
     cfg = get_config(config_file)
-    building_opts_key = config.settings.APP_CONFIG.BUILDING_OPTS_KEY
+    building_opts_key = settings.APP_CONFIG.BUILDING_OPTS_KEY
 
     # Guard against incorrect or undefined file key.
     # EPW information should be under the building options.
@@ -152,4 +152,8 @@ def main(config_file: str = typer.Argument(..., help="Path to configuration YAML
 
 
 if __name__ == '__main__':
+    # Load settings from the environment.
+    settings = config.Settings()
+
+    # Run the CLI interface.
     typer.run(main)

--- a/src/preprocessing.py
+++ b/src/preprocessing.py
@@ -72,11 +72,11 @@ def read_output(path_elec,path_gas):
     """
 
     # Load the data from blob storage.
-    s3 = acm.establish_s3_connection(acm.settings.MINIO_URL, acm.settings.MINIO_ACCESS_KEY, acm.settings.MINIO_SECRET_KEY)
-    btap_df_elec = pd.read_excel(s3.open(acm.settings.NAMESPACE.joinpath(path_elec).as_posix()))
+    s3 = acm.establish_s3_connection(settings.MINIO_URL, settings.MINIO_ACCESS_KEY, settings.MINIO_SECRET_KEY)
+    btap_df_elec = pd.read_excel(s3.open(settings.NAMESPACE.joinpath(path_elec).as_posix()))
 
     if path_gas:
-        btap_df_gas = pd.read_excel(s3.open(acm.settings.NAMESPACE.joinpath(path_gas).as_posix()))
+        btap_df_gas = pd.read_excel(s3.open(settings.NAMESPACE.joinpath(path_gas).as_posix()))
 
         btap_df = pd.concat([btap_df_elec, btap_df_gas], ignore_index=True)
     else:
@@ -109,9 +109,9 @@ def read_weather(path: str) -> pd.DataFrame:
        btap_df: Dataframe containing the clean weather file.
     """
     # Load the data from blob storage.
-    s3 = acm.establish_s3_connection(acm.settings.MINIO_URL, acm.settings.MINIO_ACCESS_KEY, acm.settings.MINIO_SECRET_KEY)
+    s3 = acm.establish_s3_connection(settings.MINIO_URL, settings.MINIO_ACCESS_KEY, settings.MINIO_SECRET_KEY)
     #weather_df = pd.read_parquet(s3.open(acm.settings.NAMESPACE.joinpath(path).as_posix()))
-    weather_df = pd.read_csv(s3.open(acm.settings.NAMESPACE.joinpath(path).as_posix()))
+    weather_df = pd.read_csv(s3.open(settings.NAMESPACE.joinpath(path).as_posix()))
 
     # Remove spurious columns.
     weather_df = clean_data(weather_df)
@@ -150,11 +150,11 @@ def read_hour_energy(path_elec,path_gas,floor_sq):
        energy_hour_melt: Dataframe containing the clean and transposed hourly energy file.
     """
 
-    s3 = acm.establish_s3_connection(acm.settings.MINIO_URL, acm.settings.MINIO_ACCESS_KEY, acm.settings.MINIO_SECRET_KEY)
-    energy_hour_df_elec = pd.read_csv(s3.open(acm.settings.NAMESPACE.joinpath(path_elec).as_posix()))
+    s3 = acm.establish_s3_connection(settings.MINIO_URL, settings.MINIO_ACCESS_KEY, settings.MINIO_SECRET_KEY)
+    energy_hour_df_elec = pd.read_csv(s3.open(settings.NAMESPACE.joinpath(path_elec).as_posix()))
 
     if path_gas:
-        energy_hour_df_gas = pd.read_csv(s3.open(acm.settings.NAMESPACE.joinpath(path_gas).as_posix()))
+        energy_hour_df_gas = pd.read_csv(s3.open(settings.NAMESPACE.joinpath(path_gas).as_posix()))
 
 
         energy_hour_df = pd.concat([energy_hour_df_elec, energy_hour_df_gas], ignore_index=True)
@@ -363,6 +363,10 @@ def process_data(args):
 
 
 if __name__ == '__main__':
+    # Load settings from the environment
+    settings = acm.Settings()
+
+    # Prepare the argument parser
     parser = argparse.ArgumentParser()
 
     # Paths must be passed in, not hardcoded

--- a/src/preprocessing.py
+++ b/src/preprocessing.py
@@ -31,15 +31,17 @@ import plot as pl
 def clean_data(df):
     """
     Basic cleaning of the data using the following criterion:
+
     - dropping any column with more than 50% missing values
-    The 50% threshold is a way to eliminate columns with too much missing values in the dataset.
-   We cant use N/A as it will elimnate the entire row /datapoint_id. Giving the number of features we have to work it its better we eliminate
-   columns with features that have too much missing values than to eliminate by rows, which is what N/A will do .
+      The 50% threshold is a way to eliminate columns with too much missing values in the dataset.
+      We cant use N/A as it will elimnate the entire row /datapoint_id. Giving the number of features we have to work it its better we eliminate
+      columns with features that have too much missing values than to eliminate by rows, which is what N/A will do .
     - dropping columns with 2 unquie values
-    For columns with 2 or 1 unique values are dropped during data cleaning as they have low variance
-    and hence have little or no significant contribution to the accuracy of the model.
+      For columns with 2 or 1 unique values are dropped during data cleaning as they have low variance
+      and hence have little or no significant contribution to the accuracy of the model.
+
     Args:
-        df: dataset to be cleaned
+       df: dataset to be cleaned
 
     Returns:
        clean dataframe


### PR DESCRIPTION
Fix #35 by creating a section for API docs pages and calling `automodule` on each script in `src/`.

Builds API documentation pages and populates the module index. Also orients the main processing flow graphic horizontally to make better use of available space.